### PR TITLE
Adding a default lat and lng to the map page

### DIFF
--- a/frontend/src/pages/map/MapPage.js
+++ b/frontend/src/pages/map/MapPage.js
@@ -7,12 +7,13 @@ import '../../css/MapPageTemp.css'; // Import the CSS file
 function MapPageTemp() {
   const location = useLocation();
   const params = new URLSearchParams(location.search);
-  const lat = parseFloat(params.get('lat'));
-  const lng = parseFloat(params.get('lng'));
+  let lat = parseFloat(params.get('lat'));
+  let lng = parseFloat(params.get('lng'));
 
   // Check if lat and lng are valid numbers
   if (isNaN(lat) || isNaN(lng)) {
-    return <div>Invalid coordinates provided in the URL</div>;
+    lat=36.1173;
+    lng=-115.1761;
   }
 
   return (


### PR DESCRIPTION
# Description

A quick fix to the map page for the Nav Bar. Gives default lat and LNG to the the map component.

# Type of change

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
